### PR TITLE
feat: local command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The package provides a command line interface to create markdown with details ab
 
 ### Extracting info about published packages
 
-Call it with a list of packages and pipe the output to a file:
+Simply call it with a list of packages and pipe the output to a file:
 
 ```bash
-barnard59-docs npm barnard59-core barnard59-base > docs.md
+barnard59-docs barnard59-core barnard59-base > docs.md
 ```
 
 The packages are listed in the order they are given.
@@ -23,13 +23,11 @@ The templates are evaluated as ES6 template strings.
 ### Extracting info about local package
 
 ```bash
-barnard59-docs local
+barnard59-docs --local .
 ```
 
-By default, is looks for a `package.json` and `manifest.ttl` in local working directory. Additional options can be provided to change their locations.
+By default, is looks for a `package.json` and `manifest.ttl` in each of the given directories. Additional option can be provided to change the expected manifest's location relative to the package.
 
 ```bash
-barnard59-docs local package/barnard59-example --manifest about.ttl
+barnard59-docs --local --manifest about.ttl package/barnard59-example
 ```
-
-`manifest` is relative to the provided path, and not current working directory!

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The package provides a command line interface to create markdown with details ab
 
 ### Extracting info about published packages
 
-Simply call it with a list of packages and pipe the output to a file:
+Just call it with a list of packages and pipe the output to a file:
 
 ```bash
 barnard59-docs barnard59-core barnard59-base > docs.md

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 
 ## CLI
 
-The package provides a command line interface.
-Just call it with a list of packages and pipe the output to a file:
+The package provides a command line interface to create markdown with details about packages compatible with barnard59
+
+### Extracting info about published packages
+
+Call it with a list of packages and pipe the output to a file:
 
 ```bash
-barnard59-docs barnard59-core barnard59-base > docs.md
+barnard59-docs npm barnard59-core barnard59-base > docs.md
 ```
 
 The packages are listed in the order they are given.
@@ -16,3 +19,17 @@ https://unpkg.com/ is used to resolve the `manifest.ttl` and `package.json` file
 The markdown is generated based on the templates `package.template` and `operation.template`.
 Both templates can be overwritten with command line arguments.
 The templates are evaluated as ES6 template strings.
+
+### Extracting info about local package
+
+```bash
+barnard59-docs local
+```
+
+By default, is looks for a `package.json` and `manifest.ttl` in local working directory. Additional options can be provided to change their locations.
+
+```bash
+barnard59-docs local package/barnard59-example --manifest about.ttl
+```
+
+`manifest` is relative to the provided path, and not current working directory!

--- a/bin/barnard59-docs.js
+++ b/bin/barnard59-docs.js
@@ -8,35 +8,19 @@ const program = new Command()
 program
   .option('--operation-template <filename>', 'ES6 template for an operation')
   .option('--package-template <filename>', 'ES6 template for a package')
-
-program.command('npm <packages...>')
-  .action(async (packages) => {
+  .option('--local', 'Treat arguments as paths to package directories')
+  .option('--manifest <manifest>', 'Path to manifest.ttl relative to package.json', 'manifest.ttl')
+  .action(async () => {
+    const opts = program.opts()
     const output = []
 
-    for (const name of packages) {
-      const info = await packageInfo({ name })
-      const manifest = await packageManifest({ name })
+    for (const name of program.args) {
+      const info = await packageInfo(name, opts)
+      const manifest = await packageManifest(name, opts)
 
-      output.push(infoToMarkdown(info, program.opts()))
-      output.push(manifestToMarkdown(manifest, program.opts()))
+      output.push(infoToMarkdown(info, opts))
+      output.push(manifestToMarkdown(manifest, opts))
     }
-
-    const markdown = output.join('\n')
-
-    process.stdout.write(markdown)
-  })
-
-program.command('local [dir]')
-  .description('Load local package from given directory (relative to working dir)')
-  .option('--manifest <manifest>', 'Path to manifest.ttl relative to <dir>', 'manifest.ttl')
-  .action(async (dir = '.', opts) => {
-    const output = []
-
-    const info = await packageInfo({ dir })
-    const manifest = await packageManifest({ dir, manifest: opts.manifest })
-
-    output.push(infoToMarkdown(info, program.opts()))
-    output.push(manifestToMarkdown(manifest, program.opts()))
 
     const markdown = output.join('\n')
 

--- a/bin/barnard59-docs.js
+++ b/bin/barnard59-docs.js
@@ -9,7 +9,6 @@ program
   .option('--operation-template <filename>', 'ES6 template for an operation')
   .option('--package-template <filename>', 'ES6 template for a package')
   .option('--local', 'Treat arguments as paths to package directories')
-  .option('--manifest <manifest>', 'Path to manifest.ttl relative to package.json', 'manifest.ttl')
   .action(async () => {
     const opts = program.opts()
     const output = []

--- a/bin/barnard59-docs.js
+++ b/bin/barnard59-docs.js
@@ -9,18 +9,42 @@ program
   .option('--operation-template <filename>', 'ES6 template for an operation')
   .option('--package-template <filename>', 'ES6 template for a package')
 
-program.parse(process.argv)
+program.command('npm <packages...>')
+  .action(async (packages) => {
+    const output = []
 
-const output = []
+    for (const name of packages) {
+      const info = await packageInfo({ name })
+      const manifest = await packageManifest({ name })
 
-for (const name of program.args) {
-  const info = await packageInfo(name)
-  const manifest = await packageManifest(name)
+      output.push(infoToMarkdown(info, program.opts()))
+      output.push(manifestToMarkdown(manifest, program.opts()))
+    }
 
-  output.push(infoToMarkdown(info, program.opts()))
-  output.push(manifestToMarkdown(manifest, program.opts()))
-}
+    const markdown = output.join('\n')
 
-const markdown = output.join('\n')
+    process.stdout.write(markdown)
+  })
 
-process.stdout.write(markdown)
+program.command('local [dir]')
+  .description('Load local package from given directory (relative to working dir)')
+  .option('--manifest <manifest>', 'Path to manifest.ttl relative to <dir>', 'manifest.ttl')
+  .action(async (dir = '.', opts) => {
+    const output = []
+
+    const info = await packageInfo({ dir })
+    const manifest = await packageManifest({ dir, manifest: opts.manifest })
+
+    output.push(infoToMarkdown(info, program.opts()))
+    output.push(manifestToMarkdown(manifest, program.opts()))
+
+    const markdown = output.join('\n')
+
+    process.stdout.write(markdown)
+  })
+
+program.parseAsync(process.argv)
+  .catch(e => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ const ns = {
 
 async function packageInfo ({ name, dir }) {
   if (!name) {
-    return readFile(path.resolve(process.cwd(), dir, 'package.json'))
+    const buffer = await readFile(path.resolve(process.cwd(), dir, 'package.json'))
+    return JSON.parse(buffer.toString())
   }
 
   const res = await fetch(`https://unpkg.com/${name}/package.json`)

--- a/index.js
+++ b/index.js
@@ -17,9 +17,9 @@ const ns = {
   rdfs: namespace('http://www.w3.org/2000/01/rdf-schema#')
 }
 
-async function packageInfo ({ name, dir }) {
-  if (!name) {
-    const buffer = await readFile(path.resolve(process.cwd(), dir, 'package.json'))
+async function packageInfo (name, { local }) {
+  if (local) {
+    const buffer = await readFile(path.resolve(process.cwd(), name, 'package.json'))
     return JSON.parse(buffer.toString())
   }
 
@@ -32,10 +32,10 @@ async function packageInfo ({ name, dir }) {
   return res.json()
 }
 
-async function packageManifest ({ name, dir, manifest }) {
-  const manifestPtr = name
-    ? clownface().namedNode(`https://unpkg.com/${name}/manifest.ttl`)
-    : clownface().namedNode(`file:${path.resolve(process.cwd(), dir, manifest)}`)
+async function packageManifest (name, { local, manifest }) {
+  const manifestPtr = local
+    ? clownface().namedNode(`file:${path.resolve(process.cwd(), name, manifest)}`)
+    : clownface().namedNode(`https://unpkg.com/${name}/manifest.ttl`)
 
   const res = await manifestPtr.fetch()
 

--- a/index.js
+++ b/index.js
@@ -32,9 +32,9 @@ async function packageInfo (name, { local }) {
   return res.json()
 }
 
-async function packageManifest (name, { local, manifest }) {
+async function packageManifest (name, { local }) {
   const manifestPtr = local
-    ? clownface().namedNode(`file:${path.resolve(process.cwd(), name, manifest)}`)
+    ? clownface().namedNode(`file:${path.resolve(process.cwd(), name, 'manifest.ttl')}`)
     : clownface().namedNode(`https://unpkg.com/${name}/manifest.ttl`)
 
   const res = await manifestPtr.fetch()

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Generate docs based on barnard59 manifest data",
   "type": "module",
   "main": "index.js",
+  "bin": "bin/barnard59-docs.js",
   "scripts": {},
   "repository": {
     "type": "git",
@@ -19,9 +20,8 @@
   "dependencies": {
     "@rdfjs/fetch": "^2.1.0",
     "@rdfjs/namespace": "^1.1.0",
-    "clownface": "^1.2.0",
-    "commander": "^7.1.0",
-    "rdf-ext": "^1.3.0"
+    "clownface-io": "zazuko/clownface-io#tpluscode-proposals",
+    "commander": "^7.1.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Adds a new option to treat args as paths relative to CWD:

* `barnard59-docs --local ../path/to/barnard59-core`

Uses clownface-io to transparent load the manifest. 

Fixes #2
Fixes #4